### PR TITLE
Update zeplin from 2.4.0 to 3.0.1

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,11 +1,11 @@
 $packageName = "zeplin"
 $fileType = "exe"
 $silentArgs = "-s"
-$url = 'https://pkg.zeplin.io/windows/2.4.0/ia32/zeplin-installer-ia32.exe'
-$url64 = 'https://pkg.zeplin.io/windows/2.4.0/x64/zeplin-installer-x64.exe'
+$url = 'https://pkg.zeplin.io/windows/3.0.1/ia32/zeplin-installer-ia32.exe'
+$url64 = 'https://pkg.zeplin.io/windows/3.0.1/x64/zeplin-installer-x64.exe'
 $checksumType = 'sha256';
-$checksum32 = '8ae9be4dd2c12cd21f301e0e307d7408e3d88cfa96e2d7395f01c492185846a7';
-$checksum64 = '0c64a487ccfd1fb8f0e92e2018756164450dca21c52638b235cfd27a1e7950ee';
+$checksum32 = '2D9E0382DB5FDBBA52DB4C0BA1F4135CDD9AA649C29BDCF858D27398C3D21BF8';
+$checksum64 = '0259D64231965E4E644DA381C3558A1A3B7BAEBFDB4E0ED70F568B49E4E0071F';
 $checksum = '';
 if ([Environment]::Is64BitOperatingSystem -and !$env:chocolateyForceX86 ) {
     Write-Output 'Installing 64 bit version.';

--- a/zeplin.nuspec
+++ b/zeplin.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>zeplin</id>
     <title>Zeplin for Windows</title>
-    <version>2.4.0</version>
+    <version>3.0.1</version>
     <authors>Zeplin, Inc.</authors>
     <owners>zed</owners>
     <summary>Zeplin for Windows</summary>


### PR DESCRIPTION
I'm using your zeplin package well :)
Zeplin 3.0.1 is released. This PR for your package!